### PR TITLE
Add appointment completion workflow

### DIFF
--- a/src/components/DentistDashboard.tsx
+++ b/src/components/DentistDashboard.tsx
@@ -203,6 +203,40 @@ export function DentistDashboard() {
     }
   };
 
+  const handleCompleteAppointment = async (
+    appointmentId: string,
+    summary: string
+  ) => {
+    try {
+      const { error: updateError } = await supabase
+        .from('appointments')
+        .update({ status: 'completed', consultation_notes: summary })
+        .eq('id', appointmentId);
+
+      if (updateError) throw updateError;
+
+      setAppointments(prev =>
+        prev.map(apt =>
+          apt.id === appointmentId
+            ? { ...apt, status: 'completed' as const, consultation_notes: summary }
+            : apt
+        )
+      );
+
+      toast({
+        title: 'Appointment Completed',
+        description: 'Marked appointment as completed.',
+      });
+    } catch (error: any) {
+      console.error('Error completing appointment:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to complete appointment',
+        variant: 'destructive',
+      });
+    }
+  };
+
   if (profileLoading || loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -366,6 +400,7 @@ export function DentistDashboard() {
           setSelectedAppointment(null);
         }}
         onSaveSummary={handleSaveSummary}
+        onComplete={handleCompleteAppointment}
       />
     </div>
   );

--- a/src/components/PatientModal.tsx
+++ b/src/components/PatientModal.tsx
@@ -39,6 +39,7 @@ interface PatientModalProps {
   open: boolean;
   onClose: () => void;
   onSaveSummary: (appointmentId: string, summary: string) => Promise<void>;
+  onComplete: (appointmentId: string, summary: string) => Promise<void>;
   loading?: boolean;
 }
 
@@ -75,6 +76,28 @@ export function PatientModal({
       onClose();
     } catch (error) {
       console.error('Failed to save summary:', error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleComplete = async () => {
+    if (!appointment) return;
+
+    let finalSummary = summary.trim();
+    const feedback = window.prompt('How did the appointment go?');
+    if (feedback && feedback.trim()) {
+      finalSummary = finalSummary
+        ? `${finalSummary}\n\n${feedback.trim()}`
+        : feedback.trim();
+    }
+
+    setSaving(true);
+    try {
+      await onComplete(appointment.id, finalSummary);
+      onClose();
+    } catch (error) {
+      console.error('Failed to complete appointment:', error);
     } finally {
       setSaving(false);
     }
@@ -210,8 +233,8 @@ export function PatientModal({
               <X className="h-4 w-4 mr-2" />
               Cancel
             </Button>
-            <Button 
-              onClick={handleSave} 
+            <Button
+              onClick={handleSave}
               disabled={!summary.trim() || saving}
             >
               {saving ? (
@@ -225,6 +248,9 @@ export function PatientModal({
                   Save Notes
                 </>
               )}
+            </Button>
+            <Button onClick={handleComplete} disabled={saving} variant="secondary">
+              {saving ? 'Completing...' : 'Complete'}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add `onComplete` support in `PatientModal`
- allow dentists to mark appointments as completed and capture feedback
- handle completion update in `DentistDashboard`

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_b_688cc2c40898832c9adf651a7160ef61