### PR TITLE
Fix agenda dentist dependency

### DIFF
--- a/src/components/Agenda.tsx
+++ b/src/components/Agenda.tsx
@@ -94,7 +94,7 @@ export function Agenda() {
     if (selectedDate) {
       fetchAppointments(selectedDate);
     }
-  }, [selectedDate, profile]);
+  }, [selectedDate, profile, dentist]);
 
   const fetchAppointments = async (date: Date) => {
     if (!profile) return;


### PR DESCRIPTION
## Summary
- trigger appointment fetching once dentist data is loaded

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-explicit-any` errors)*

------
https://chatgpt.com/codex/tasks/task_b_688cdddaf224832cb47c35bc36f7bdd5