### PR TITLE
Fix notes table reference

### DIFF
--- a/src/components/PatientNotes.tsx
+++ b/src/components/PatientNotes.tsx
@@ -31,7 +31,7 @@ export default function PatientNotes({ patientId, dentistId }: PatientNotesProps
     try {
       setLoading(true);
       const { data, error } = await supabase
-        .from('patient_notes')
+        .from('notes')
         .select('*')
         .eq('patient_id', patientId)
         .eq('dentist_id', dentistId)
@@ -55,7 +55,7 @@ export default function PatientNotes({ patientId, dentistId }: PatientNotesProps
     if (!newNote.trim()) return;
     try {
       const { data, error } = await supabase
-        .from('patient_notes')
+        .from('notes')
         .insert({
           patient_id: patientId,
           dentist_id: dentistId,


### PR DESCRIPTION
## Summary
- update PatientNotes to use the `notes` table instead of the old `patient_notes`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688d0d6cec04832caed1a7c760b8b219