### PR TITLE
Fix dentist id usage and status defaults

### DIFF
--- a/src/components/AppointmentForm.tsx
+++ b/src/components/AppointmentForm.tsx
@@ -21,7 +21,7 @@ export default function AppointmentForm({ patientId, dentistId, treatmentPlans, 
     appointment_date: new Date().toISOString().slice(0,16),
     reason: '',
     notes: '',
-    status: 'confirmed',
+    status: 'pending',
     treatment_plan_id: ''
   });
 

--- a/src/components/DentistDashboard.tsx
+++ b/src/components/DentistDashboard.tsx
@@ -68,12 +68,8 @@ export function DentistDashboard() {
   }, [profile]);
 
   const fetchAppointments = async () => {
-    // For Romeo's account, use Virginie's dentist ID directly
-    let dentistId = '46067bae-18f6-4769-b8e4-be48cc18d273'; // Virginie's dentist ID
-    
-    if (profile?.email !== 'romeojackson199@gmail.com' && dentist?.id) {
-      dentistId = dentist.id; // Use their own dentist ID for other users
-    }
+    if (!dentist?.id) return;
+    const dentistId = dentist.id;
 
     try {
       setLoading(true);

--- a/src/components/PatientManagement.tsx
+++ b/src/components/PatientManagement.tsx
@@ -85,10 +85,7 @@ export default function PatientManagement() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogType, setDialogType] = useState<'treatment' | 'record' | 'prescription' | 'appointment'>('treatment');
 
-  let dentistId = '46067bae-18f6-4769-b8e4-be48cc18d273';
-  if (profile?.email !== 'romeojackson199@gmail.com' && dentist?.id) {
-    dentistId = dentist.id;
-  }
+  const dentistId = dentist?.id;
 
   useEffect(() => {
     if (profile) {
@@ -103,8 +100,9 @@ export default function PatientManagement() {
   }, [selectedPatient]);
 
   const fetchPatients = async () => {
+    if (!dentistId) return;
     try {
-      let dentistIdParam = dentistId;
+      const dentistIdParam = dentistId;
       // Get patients from appointments
       const { data: appointmentPatients, error } = await supabase
         .from('appointments')
@@ -148,6 +146,7 @@ export default function PatientManagement() {
   };
 
   const fetchPatientData = async (patientId: string) => {
+    if (!dentistId) return;
     try {
       const dentistIdParam = dentistId;
       // Fetch treatment plans
@@ -234,6 +233,14 @@ export default function PatientManagement() {
 
   if (loading) {
     return <div className="flex justify-center items-center h-64">Loading patients...</div>;
+  }
+
+  if (!dentistId) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        Dentist information missing
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- use dentist ID from profile rather than hard-coded value
- fetch agenda appointments when a dentist ID exists and show status badges
- default new appointments to `pending`
- ensure patient management queries use the logged-in dentist ID

## Testing
- `npm run lint` *(fails: unexpected any types and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_688d1454d44c832c97e72b235fbb8f78